### PR TITLE
Make `HtmlEncodedString` a suitable base for MVC's `HtmlString`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,17 @@
 [Bb]in/
 TestResults/
 .nuget/
+*.sln.ide/
 _ReSharper.*/
 packages/
 artifacts/
 PublishProfiles/
+.vs/
+bower_components/
+node_modules/
+**/wwwroot/lib/
+debugSettings.json
+project.lock.json
 *.user
 *.suo
 *.cache
@@ -23,5 +30,8 @@ nuget.exe
 *.ncrunchsolution
 *.*sdf
 *.ipch
+.settings
 *.sln.ide
-project.lock.json
+node_modules
+**/[Cc]ompiler/[Rr]esources/**/*.js
+*launchSettings.json

--- a/src/Microsoft.AspNet.Html.Abstractions/HtmlContentBuilderExtensions.cs
+++ b/src/Microsoft.AspNet.Html.Abstractions/HtmlContentBuilderExtensions.cs
@@ -99,6 +99,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder AppendLine(this IHtmlContentBuilder builder)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Append(HtmlEncodedString.NewLine);
             return builder;
         }
@@ -112,6 +117,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder AppendLine(this IHtmlContentBuilder builder, string unencoded)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Append(unencoded);
             builder.Append(HtmlEncodedString.NewLine);
             return builder;
@@ -125,6 +135,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder AppendLine(this IHtmlContentBuilder builder, IHtmlContent content)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Append(content);
             builder.Append(HtmlEncodedString.NewLine);
             return builder;
@@ -139,6 +154,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder AppendHtmlLine(this IHtmlContentBuilder builder, string encoded)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.AppendHtml(encoded);
             builder.Append(HtmlEncodedString.NewLine);
             return builder;
@@ -153,6 +173,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder SetContent(this IHtmlContentBuilder builder, string unencoded)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Clear();
             builder.Append(unencoded);
             return builder;
@@ -166,6 +191,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder SetContent(this IHtmlContentBuilder builder, IHtmlContent content)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Clear();
             builder.Append(content);
             return builder;
@@ -180,6 +210,11 @@ namespace Microsoft.AspNet.Html
         /// <returns>The <see cref="IHtmlContentBuilder"/>.</returns>
         public static IHtmlContentBuilder SetHtmlContent(this IHtmlContentBuilder builder, string encoded)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
             builder.Clear();
             builder.AppendHtml(encoded);
             return builder;
@@ -256,8 +291,14 @@ namespace Microsoft.AspNet.Html
 
             public string Format(string format, object arg, IFormatProvider formatProvider)
             {
-                // This is the case we need to special case. We trust the IHtmlContent instance to do the
-                // right thing with encoding.
+                // These are the cases we need to special case. We trust the HtmlEncodedString or IHtmlContent instance
+                // to do the right thing with encoding.
+                var htmlString = arg as HtmlEncodedString;
+                if (htmlString != null)
+                {
+                    return htmlString.ToString();
+                }
+
                 var htmlContent = arg as IHtmlContent;
                 if (htmlContent != null)
                 {

--- a/src/Microsoft.AspNet.Html.Abstractions/HtmlEncodedString.cs
+++ b/src/Microsoft.AspNet.Html.Abstractions/HtmlEncodedString.cs
@@ -2,16 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Text.Encodings.Web;
 
 namespace Microsoft.AspNet.Html
 {
     /// <summary>
-    /// An <see cref="IHtmlContent"/> impelementation that wraps an HTML encoded <see cref="string"/>.
+    /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see cref="string"/>.
     /// </summary>
-    [DebuggerDisplay("{DebuggerToString()}")]
     public class HtmlEncodedString : IHtmlContent
     {
         /// <summary>
@@ -27,23 +25,29 @@ namespace Microsoft.AspNet.Html
         /// <param name="value">The HTML encoded value.</param>
         public HtmlEncodedString(string value)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
             _value = value;
         }
 
         /// <inheritdoc />
         public void WriteTo(TextWriter writer, HtmlEncoder encoder)
         {
+            if (writer == null)
+            {
+                throw new ArgumentNullException(nameof(writer));
+            }
+
+            if (encoder == null)
+            {
+                throw new ArgumentNullException(nameof(encoder));
+            }
+
             writer.Write(_value);
         }
 
-        private string DebuggerToString()
+        /// <inheritdoc />
+        public override string ToString()
         {
-            return _value;
+            return _value ?? string.Empty;
         }
     }
 }

--- a/test/Microsoft.AspNet.Html.Abstractions.Test/HtmlContentBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNet.Html.Abstractions.Test/HtmlContentBuilderExtensionsTest.cs
@@ -159,6 +159,19 @@ namespace Microsoft.AspNet.Html.Test
         }
 
         [Fact]
+        public void Builder_AppendFormat_HtmlEncodedString()
+        {
+            // Arrange
+            var builder = new TestHtmlContentBuilder();
+
+            // Act
+            builder.AppendFormat("{0}!", new HtmlEncodedString("First"));
+
+            // Assert
+            Assert.Equal("First!", HtmlContentToString(builder));
+        }
+
+        [Fact]
         public void Builder_AppendFormatContent_With1Argument()
         {
             // Arrange


### PR DESCRIPTION
- #5
- provide `ToString()` implementation
- add missing `null` checks in `WriteTo()`; remove extraneous one in the constructor
- special-case `HtmlEncodedString` in `IHtmlContentBuilder.AppendFormat()` extension method

nits:
- ignore more files
- add missing `null` checks in `HtmlContentBuilderExtensions` too