### PR TITLE
Don't reference facades in NuSpec

### DIFF
--- a/src/Microsoft.AspNetCore.Html.Abstractions/project.json
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/project.json
@@ -19,8 +19,8 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.IO": "",
-        "System.Runtime": ""
+        "System.IO": { "type": "build" },
+        "System.Runtime": { "type": "build" }
       }
     },
     "netstandard1.3": {

--- a/src/Microsoft.Extensions.WebEncoders/project.json
+++ b/src/Microsoft.Extensions.WebEncoders/project.json
@@ -22,8 +22,8 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.IO": "",
-        "System.Runtime": ""
+        "System.IO": { "type": "build" },
+        "System.Runtime": { "type": "build" }
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
These can be removed entirely after dotnet/cli#164