### PR TITLE
Rename `HtmlEncodedString` => `HtmlString`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/cu9y78vsdp19e
 
 Travis:   [![Travis](https://travis-ci.org/aspnet/HtmlAbstractions.svg?branch=dev)](https://travis-ci.org/aspnet/HtmlAbstractions)
 
-HTML abstractions used for building HTML content, including types such as `HtmlEncodedString` and `IHtmlContent`.
+HTML abstractions used for building HTML content, including types such as `HtmlString` and `IHtmlContent`.
 
 This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.

--- a/src/Microsoft.AspNetCore.Html.Abstractions/HtmlContentBuilder.cs
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/HtmlContentBuilder.cs
@@ -83,7 +83,7 @@ namespace Microsoft.AspNetCore.Html
         {
             if (!string.IsNullOrEmpty(encoded))
             {
-                Entries.Add(new HtmlEncodedString(encoded));
+                Entries.Add(new HtmlString(encoded));
             }
 
             return this;

--- a/src/Microsoft.AspNetCore.Html.Abstractions/HtmlContentBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/HtmlContentBuilderExtensions.cs
@@ -104,7 +104,7 @@ namespace Microsoft.AspNetCore.Html
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.AppendHtml(HtmlEncodedString.NewLine);
+            builder.AppendHtml(HtmlString.NewLine);
             return builder;
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.AspNetCore.Html
             }
 
             builder.Append(unencoded);
-            builder.AppendHtml(HtmlEncodedString.NewLine);
+            builder.AppendHtml(HtmlString.NewLine);
             return builder;
         }
 
@@ -141,7 +141,7 @@ namespace Microsoft.AspNetCore.Html
             }
 
             builder.AppendHtml(content);
-            builder.AppendHtml(HtmlEncodedString.NewLine);
+            builder.AppendHtml(HtmlString.NewLine);
             return builder;
         }
 
@@ -160,7 +160,7 @@ namespace Microsoft.AspNetCore.Html
             }
 
             builder.AppendHtml(encoded);
-            builder.AppendHtml(HtmlEncodedString.NewLine);
+            builder.AppendHtml(HtmlString.NewLine);
             return builder;
         }
 

--- a/src/Microsoft.AspNetCore.Html.Abstractions/HtmlFormattableString.cs
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/HtmlFormattableString.cs
@@ -10,7 +10,7 @@ using System.Text.Encodings.Web;
 namespace Microsoft.AspNetCore.Html
 {
     /// <summary>
-    /// An <see cref="IHtmlContent"/> implementation of composite string formatting 
+    /// An <see cref="IHtmlContent"/> implementation of composite string formatting
     /// (see https://msdn.microsoft.com/en-us/library/txafckwd(v=vs.110).aspx) which HTML encodes
     /// formatted arguments.
     /// </summary>
@@ -107,9 +107,9 @@ namespace Microsoft.AspNetCore.Html
 
             public string Format(string format, object arg, IFormatProvider formatProvider)
             {
-                // These are the cases we need to special case. We trust the HtmlEncodedString or IHtmlContent instance
+                // These are the cases we need to special case. We trust the HtmlString or IHtmlContent instance
                 // to do the right thing with encoding.
-                var htmlString = arg as HtmlEncodedString;
+                var htmlString = arg as HtmlString;
                 if (htmlString != null)
                 {
                     return htmlString.ToString();

--- a/src/Microsoft.AspNetCore.Html.Abstractions/HtmlString.cs
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/HtmlString.cs
@@ -10,18 +10,23 @@ namespace Microsoft.AspNetCore.Html
     /// <summary>
     /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see cref="string"/>.
     /// </summary>
-    public class HtmlEncodedString : IHtmlContent
+    public class HtmlString : IHtmlContent
     {
         /// <summary>
-        /// An <see cref="IHtmlContent"/> instance for <see cref="Environment.NewLine"/>.
+        /// An <see cref="HtmlString"/> instance for <see cref="Environment.NewLine"/>.
         /// </summary>
-        public static readonly IHtmlContent NewLine = new HtmlEncodedString(Environment.NewLine);
+        public static readonly HtmlString NewLine = new HtmlString(Environment.NewLine);
 
         /// <summary>
-        /// Creates a new <see cref="HtmlEncodedString"/>.
+        /// An <see cref="HtmlString"/> instance for <see cref="string.Empty"/>.
+        /// </summary>
+        public static readonly HtmlString Empty = new HtmlString(string.Empty);
+
+        /// <summary>
+        /// Creates a new <see cref="HtmlString"/>.
         /// </summary>
         /// <param name="value">The HTML encoded value.</param>
-        public HtmlEncodedString(string value)
+        public HtmlString(string value)
         {
             Value = value;
         }

--- a/src/Microsoft.AspNetCore.Html.Abstractions/project.json
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/project.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "description": "ASP.NET Core HTML abstractions used for building HTML content.\r\nCommonly used types:\r\nMicrosoft.AspNetCore.Html.HtmlEncodedString\r\nMicrosoft.AspNetCore.Html.IHtmlContent",
+  "description": "ASP.NET Core HTML abstractions used for building HTML content.\r\nCommonly used types:\r\nMicrosoft.AspNetCore.Html.HtmlString\r\nMicrosoft.AspNetCore.Html.IHtmlContent",
   "packOptions": {
     "repository": {
       "type": "git",

--- a/test/Microsoft.AspNetCore.Html.Abstractions.Test/HtmlContentBuilderExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Html.Abstractions.Test/HtmlContentBuilderExtensionsTest.cs
@@ -159,13 +159,13 @@ namespace Microsoft.AspNetCore.Html.Test
         }
 
         [Fact]
-        public void Builder_AppendFormat_HtmlEncodedString()
+        public void Builder_AppendFormat_HtmlString()
         {
             // Arrange
             var builder = new TestHtmlContentBuilder();
 
             // Act
-            builder.AppendFormat("{0}!", new HtmlEncodedString("First"));
+            builder.AppendFormat("{0}!", new HtmlString("First"));
 
             // Assert
             Assert.Equal("First!", HtmlContentToString(builder));

--- a/test/Microsoft.AspNetCore.Html.Abstractions.Test/HtmlFormattableStringTest.cs
+++ b/test/Microsoft.AspNetCore.Html.Abstractions.Test/HtmlFormattableStringTest.cs
@@ -54,10 +54,10 @@ namespace Microsoft.AspNetCore.Html
         }
 
         [Fact]
-        public void HtmlFormattableString_WithHtmlEncodedString()
+        public void HtmlFormattableString_WithHtmlString()
         {
             // Arrange
-            var formattableString = new HtmlFormattableString("{0}!", new HtmlEncodedString("First"));
+            var formattableString = new HtmlFormattableString("{0}!", new HtmlString("First"));
 
             // Act
             var result = HtmlContentToString(formattableString);
@@ -89,7 +89,7 @@ namespace Microsoft.AspNetCore.Html
             // Arrange
             var formattableString = new HtmlFormattableString(
                 "Happy {0}, {1}!",
-                new HtmlEncodedString("Birthday"),
+                new HtmlString("Birthday"),
                 new HtmlContentBuilder().Append("Billy"));
 
             // Act
@@ -100,10 +100,10 @@ namespace Microsoft.AspNetCore.Html
         }
 
         [Fact]
-        public void HtmlFormattableString_WithHtmlEncodedString_AndOffset()
+        public void HtmlFormattableString_WithHtmlString_AndOffset()
         {
             // Arrange
-            var formattableString = new HtmlFormattableString("{0, 20}!", new HtmlEncodedString("First"));
+            var formattableString = new HtmlFormattableString("{0, 20}!", new HtmlString("First"));
 
             // Act
             var result = HtmlContentToString(formattableString);


### PR DESCRIPTION
- This rename makes the type more consistent with its `HtmlContentBuilder` counterparts (`AppendHtml`).

#25 

/cc @rynowak @dougbu @pranavkm 