### PR TITLE
Lift Microsoft.Extensions.WebEncoders to target .NET Standard 2.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -15,4 +15,8 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,10 @@
 <Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>

--- a/src/Microsoft.AspNetCore.Html.Abstractions/Microsoft.AspNetCore.Html.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/Microsoft.AspNetCore.Html.Abstractions.csproj
@@ -9,7 +9,6 @@ Commonly used types:
 Microsoft.AspNetCore.Html.HtmlString
 Microsoft.AspNetCore.Html.IHtmlContent</Description>
     <TargetFramework>netstandard1.0</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.WebEncoders/Microsoft.Extensions.WebEncoders.csproj
+++ b/src/Microsoft.Extensions.WebEncoders/Microsoft.Extensions.WebEncoders.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Product>Microsoft .NET Extensions</Product>
     <Description>Contains registration and configuration APIs to add the core framework encoders to a dependency injection container.</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Microsoft.AspNetCore.Html.Abstractions.Test/Microsoft.AspNetCore.Html.Abstractions.Test.csproj
+++ b/test/Microsoft.AspNetCore.Html.Abstractions.Test/Microsoft.AspNetCore.Html.Abstractions.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/Microsoft.Extensions.WebEncoders.Tests/Microsoft.Extensions.WebEncoders.Tests.csproj
+++ b/test/Microsoft.Extensions.WebEncoders.Tests/Microsoft.Extensions.WebEncoders.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Part of https://github.com/aspnet/Home/issues/2045

Note: Microsoft.AspNetCore.Html.Abstractions has to remain netstandard1.0 unless we decide to upgrade Razor to ns2.0 as well (still in discussion)