### PR TITLE
Update Microsoft.AspNetCore.HtmlAbstractions to .NET Standard 2.0

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
-    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardImplicitPackageVersion>2.0.0-*</NETStandardImplicitPackageVersion>
     <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>

--- a/src/Microsoft.AspNetCore.Html.Abstractions/Microsoft.AspNetCore.Html.Abstractions.csproj
+++ b/src/Microsoft.AspNetCore.Html.Abstractions/Microsoft.AspNetCore.Html.Abstractions.csproj
@@ -8,7 +8,7 @@
 Commonly used types:
 Microsoft.AspNetCore.Html.HtmlString
 Microsoft.AspNetCore.Html.IHtmlContent</Description>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Follow up to #39 

Part of https://github.com/aspnet/Home/issues/2045

Also, resolved the issue with ns.library downgrade warnings.